### PR TITLE
`nvm` install instructions at the top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Prerequisite
+
+- Make sure you have `nvm` installed, you can check by running
+```bash
+nvm -v
+```
+
+- If you don't have `nvm`, follow the guide below for Windows, Linux, & Mac
+[freeCodeCamp: Node Version Manager – NVM Install Guide](https://www.freecodecamp.org/news/node-version-manager-nvm-install-guide/)
+
 # How to run
 
 - In the top level folder, install node


### PR DESCRIPTION
Add nvm install instructions.

While interviewing I found this guide to be helpful on my windows machine which did not previously have nvm, and was running an older version of node.